### PR TITLE
Broadcast to the Faye channel when a model is touched.

### DIFF
--- a/lib/backbone_sync-rails/faye/observer.rb
+++ b/lib/backbone_sync-rails/faye/observer.rb
@@ -28,6 +28,14 @@ module BackboneSync
           end
         end
 
+        def after_touch(model)
+          begin
+            Event.new(model, :update).broadcast
+          rescue *NET_HTTP_EXCEPTIONS => e
+            handle_net_http_exception(e)
+          end
+        end
+
         def handle_net_http_exception(exception)
           ::Rails.logger.error("")
           ::Rails.logger.error("Backbone::Sync::Rails::Faye::Observer encountered an exception:")


### PR DESCRIPTION
It seems like a fairly common idiom to include child models into their parent model via the methods hash on the mode#as_json.  The fun part is that you need to publish these changes on the Faye server and that is generally best done through touching the parent model on create/update/delete of the child object.  This patch adds that callback onto the Observer.

Apologies that this patch doesn't come with a test, but the test suite seems a bit sparse.  Just extracted the functionality from a well tested Iora suite though.
