### PR TITLE
Make it work with the current version of Backbone (0.9.1)

### DIFF
--- a/vendor/assets/javascripts/extensions/backbone.collection.idempotent.js
+++ b/vendor/assets/javascripts/extensions/backbone.collection.idempotent.js
@@ -1,11 +1,8 @@
 Backbone.Collection.prototype._addWithIdCheck = function(model, options) {
-  var idAttribute = model.idAttribute || this.model.prototype.idAttribute;
-  var modelId = model[idAttribute];
-
-  if (modelId === undefined || this.get(modelId) === undefined) {
+  if (model.id === undefined || this.get(model.id) === undefined) {
     this._addWithoutIdCheck(model, options);
   }
 };
 
-Backbone.Collection.prototype._addWithoutIdCheck = Backbone.Collection.prototype._add;
-Backbone.Collection.prototype._add = Backbone.Collection.prototype._addWithIdCheck;
+Backbone.Collection.prototype._addWithoutIdCheck = Backbone.Collection.prototype.add;
+Backbone.Collection.prototype.add = Backbone.Collection.prototype._addWithIdCheck;


### PR DESCRIPTION
The internal _add method was removed from Backbone.Collection so that the original approach did not work anymore. I also had to change the code concerning the model id. This patch is verified to work with the current version (0.9.1) of Backbone.
